### PR TITLE
Migrated to null safety

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,15 +18,14 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.2 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   filex:
     path: ../
-  path_provider: ^1.6.24
-  permission: ^0.1.7
+  flutter:
+    sdk: flutter
+  path_provider: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/bloc.dart
+++ b/lib/src/bloc.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart' as rx;
 
@@ -11,40 +10,40 @@ import "models/filesystem.dart";
 /// The main controller
 class FilexController {
   /// Provide a path
-  FilexController({@required this.path}) {
+  FilexController({required this.path}) {
     _bloc = _FilexBloc(path: path, itemController: _itemStream);
     directory = Directory(path);
     assert(
-        directory.existsSync(), "Directory ${directory.path} does not exist");
+        directory!.existsSync(), "Directory ${directory!.path} does not exist");
   }
 
   /// Current directory
-  Directory directory;
+  Directory? directory;
 
   /// The current path to use
   final String path;
 
-  _FilexBloc _bloc;
+  _FilexBloc? _bloc;
   final _itemStream = rx.ReplaySubject<List<DirectoryItem>>();
 
   /// Setter for show only dirs setting
-  set showOnlyDirectories(bool v) => _bloc.showOnlyDirectories = v;
+  set showOnlyDirectories(bool v) => _bloc!.showOnlyDirectories = v;
 
   /// Setter for show hidden files setting
-  set showHiddenFiles(bool v) => _bloc.showHiddenFiles = v;
+  set showHiddenFiles(bool v) => _bloc!.showHiddenFiles = v;
 
   /// Stream of directory items
   Stream<List<DirectoryItem>> get changefeed => _itemStream.stream;
 
   /// Delete a file or directory
-  Future<void> delete(DirectoryItem item) async => _bloc.deleteItem(item);
+  Future<void> delete(DirectoryItem item) async => _bloc!.deleteItem(item);
 
   /// Create a directory
   Future<void> createDirectory(String name) async =>
-      _bloc.createDir(directory, name);
+      _bloc!.createDir(directory!, name);
 
   /// List a directory content
-  Future<void> ls() async => _bloc.lsDir(directory);
+  Future<void> ls() async => _bloc!.lsDir(directory!);
 
   /// Dispose the controller when finished using
   void dispose() {
@@ -58,45 +57,46 @@ class FilexController {
       builder: (BuildContext context) {
         final _addDirController = TextEditingController();
         return AlertDialog(
-            title: const Text("Create a directory"),
-            actions: <Widget>[
-              FlatButton(
-                child: const Text("Cancel"),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-              ),
-              FlatButton(
-                child: const Text("Create"),
-                onPressed: () {
-                  createDirectory(_addDirController.text);
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-            content: SingleChildScrollView(
-              child: ListBody(
-                children: <Widget>[
-                  TextField(
-                    controller: _addDirController,
-                    autofocus: true,
-                    autocorrect: false,
-                  ),
-                ],
-              ),
-            ));
+          title: const Text("Create a directory"),
+          actions: <Widget>[
+            TextButton(
+              child: const Text("Cancel"),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text("Create"),
+              onPressed: () {
+                createDirectory(_addDirController.text);
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                TextField(
+                  controller: _addDirController,
+                  autofocus: true,
+                  autocorrect: false,
+                ),
+              ],
+            ),
+          ),
+        );
       },
     );
   }
 }
 
 class _FilexBloc {
-  _FilexBloc({@required this.path, @required this.itemController});
+  _FilexBloc({required this.path, required this.itemController});
 
   final String path;
   final StreamController<List<DirectoryItem>> itemController;
-  bool showOnlyDirectories;
-  bool showHiddenFiles;
+  bool showOnlyDirectories = false;
+  bool showHiddenFiles = false;
 
   Future<void> deleteItem(DirectoryItem item) async {
     try {

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -29,7 +29,7 @@ Future<void> mkdir(Directory currentDir, String name) async {
 
 /// List items in directory
 ListedDirectory getListedDirectory(Directory dir,
-    {bool showHiddenFiles, bool showOnlyDirectories}) {
+    {bool showHiddenFiles = false, bool showOnlyDirectories = false}) {
   //print("LIST DIR ${dir.path}");
   final contents = dir.listSync()..sort((a, b) => a.path.compareTo(b.path));
   final dirs = <Directory>[];

--- a/lib/src/filex.dart
+++ b/lib/src/filex.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:open_file/open_file.dart';
@@ -11,9 +10,9 @@ import "models/filesystem.dart";
 
 class _FilexState extends State<Filex> {
   _FilexState(
-      {@required this.controller,
-      this.showHiddenFiles,
-      this.showOnlyDirectories,
+      {required this.controller,
+      this.showHiddenFiles = false,
+      this.showOnlyDirectories = false,
       this.fileTrailingBuilder,
       this.directoryTrailingBuilder,
       this.fileLeadingBuilder,
@@ -21,7 +20,7 @@ class _FilexState extends State<Filex> {
       this.compact,
       this.actions,
       this.extraActions}) {
-    _initialDirectory = controller.directory;
+    _initialDirectory = controller.directory!;
     controller
       ..showOnlyDirectories = showOnlyDirectories
       ..showHiddenFiles = showHiddenFiles
@@ -30,19 +29,19 @@ class _FilexState extends State<Filex> {
 
   final bool showHiddenFiles;
   final bool showOnlyDirectories;
-  final FilexActionBuilder fileLeadingBuilder;
-  final FilexActionBuilder fileTrailingBuilder;
-  final FilexActionBuilder directoryTrailingBuilder;
-  final FilexActionBuilder directoryLeadingBuilder;
-  final bool compact;
-  final List<PredefinedAction> actions;
-  final List<FilexSlidableAction> extraActions;
+  final FilexActionBuilder? fileLeadingBuilder;
+  final FilexActionBuilder? fileTrailingBuilder;
+  final FilexActionBuilder? directoryTrailingBuilder;
+  final FilexActionBuilder? directoryLeadingBuilder;
+  final bool? compact;
+  final List<PredefinedAction>? actions;
+  final List<FilexSlidableAction>? extraActions;
   final FilexController controller;
 
-  SlidableController _slidableController;
+  SlidableController? _slidableController;
   final ScrollController _scrollController = ScrollController();
   bool _isBuilt = false;
-  Directory _initialDirectory;
+  late Directory _initialDirectory;
 
   @override
   Widget build(BuildContext context) {
@@ -57,24 +56,24 @@ class _FilexState extends State<Filex> {
           final builder = ListView.builder(
               controller: _scrollController,
               shrinkWrap: true,
-              itemCount: snapshot.data.length,
+              itemCount: snapshot.data!.length,
               itemBuilder: (BuildContext context, int index) {
-                final item = snapshot.data[index];
+                final item = snapshot.data![index];
                 Widget w;
-                if (actions.isNotEmpty) {
+                if (actions!.isNotEmpty) {
                   w = Slidable(
                     key: Key(item.filename),
                     controller: _slidableController,
                     direction: Axis.horizontal,
                     actionPane: const SlidableDrawerActionPane(),
                     actionExtentRatio: 0.25,
-                    child: compact
+                    child: compact!
                         ? _buildCompactVerticalListItem(context, item)
                         : _buildVerticalListItem(context, item),
                     actions: _getSlideIconActions(context, item),
                   );
                 } else {
-                  if (compact) {
+                  if (compact!) {
                     w = _buildCompactVerticalListItem(context, item);
                   } else {
                     w = _buildVerticalListItem(context, item);
@@ -82,13 +81,13 @@ class _FilexState extends State<Filex> {
                 }
                 return w;
               });
-          if (controller.directory.path != _initialDirectory.path) {
+          if (controller.directory!.path != _initialDirectory.path) {
             _isBuilt = true;
             return Column(
-                children: <Widget>[
-                  _topNavigation(),
-                  Expanded(child: builder)
-                ]
+              children: <Widget>[
+                _topNavigation(),
+                Expanded(child: builder),
+              ],
             );
           } else {
             _isBuilt = true;
@@ -96,10 +95,12 @@ class _FilexState extends State<Filex> {
           }
         } else {
           return Center(
-              child: Padding(
-                  padding: EdgeInsets.only(
-                      top: MediaQuery.of(context).size.height / 0.8),
-                  child: const CircularProgressIndicator()));
+            child: Padding(
+              padding: EdgeInsets.only(
+                  top: MediaQuery.of(context).size.height / 0.8),
+              child: const CircularProgressIndicator(),
+            ),
+          );
         }
       },
     );
@@ -112,7 +113,7 @@ class _FilexState extends State<Filex> {
         title: Text("..", textScaleFactor: 1.5),
       ),
       onTap: () {
-        final li = controller.directory.path.split("/")..removeLast();
+        final li = controller.directory!.path.split("/")..removeLast();
         controller.directory = Directory(li.join("/"));
         unawaited(controller.ls());
       },
@@ -146,7 +147,7 @@ class _FilexState extends State<Filex> {
 
   void _onTapDirectory(DirectoryItem item) {
     if (item.isDirectory) {
-      final p = controller.directory.path + "/" + item.filename;
+      final p = controller.directory!.path + "/" + item.filename;
       controller
         ..directory = Directory(p)
         ..ls();
@@ -160,12 +161,12 @@ class _FilexState extends State<Filex> {
     if (item.isDirectory) {
       switch (directoryLeadingBuilder != null) {
         case true:
-          w = directoryLeadingBuilder(context, item);
+          w = directoryLeadingBuilder!(context, item);
       }
     } else {
       switch (fileLeadingBuilder != null) {
         case true:
-          w = fileLeadingBuilder(context, item);
+          w = fileLeadingBuilder!(context, item);
           break;
         default:
       }
@@ -178,14 +179,14 @@ class _FilexState extends State<Filex> {
     switch (item.isDirectory) {
       case true:
         if (directoryTrailingBuilder != null) {
-          w = directoryTrailingBuilder(context, item);
+          w = directoryTrailingBuilder!(context, item);
         } else {
           w = const Text("");
         }
         break;
       default:
         if (fileTrailingBuilder != null) {
-          w = fileTrailingBuilder(context, item);
+          w = fileTrailingBuilder!(context, item);
         } else {
           w = Text("${item.filesize}");
         }
@@ -195,7 +196,7 @@ class _FilexState extends State<Filex> {
 
   List<Widget> _getSlideIconActions(BuildContext context, DirectoryItem item) {
     final ic = <Widget>[];
-    if (actions.contains(PredefinedAction.delete)) {
+    if (actions!.contains(PredefinedAction.delete)) {
       ic.add(IconSlideAction(
         caption: 'Delete',
         color: Colors.red,
@@ -203,8 +204,8 @@ class _FilexState extends State<Filex> {
         onTap: () => _confirmDeleteDialog(context, item),
       ));
     }
-    if (extraActions.isNotEmpty) {
-      for (final action in extraActions) {
+    if (extraActions!.isNotEmpty) {
+      for (final action in extraActions!) {
         ic.add(IconSlideAction(
           caption: action.name,
           color: action.color,
@@ -223,15 +224,15 @@ class _FilexState extends State<Filex> {
         return AlertDialog(
           title: Text("Delete ${item.filename}?"),
           actions: <Widget>[
-            FlatButton(
+            TextButton(
               child: const Text("Cancel"),
               onPressed: () {
                 Navigator.of(context).pop();
               },
             ),
-            FlatButton(
+            TextButton(
               child: const Text("Delete"),
-              color: Colors.red,
+              style: TextButton.styleFrom(backgroundColor: Colors.red),
               onPressed: () {
                 controller.delete(item).then((_) {
                   Navigator.of(context).pop();
@@ -260,7 +261,7 @@ class _FilexState extends State<Filex> {
 class Filex extends StatefulWidget {
   /// Provide a directory to start from
   const Filex(
-      {@required this.controller,
+      {/*required*/ required this.controller,
       this.showHiddenFiles = false,
       this.showOnlyDirectories = false,
       this.fileTrailingBuilder,
@@ -283,13 +284,13 @@ class Filex extends StatefulWidget {
   final bool showOnlyDirectories;
 
   /// Trailing builder for files
-  final FilexActionBuilder fileTrailingBuilder;
+  final FilexActionBuilder? fileTrailingBuilder;
 
   /// Trailing builder for directory
-  final FilexActionBuilder directoryTrailingBuilder;
+  final FilexActionBuilder? directoryTrailingBuilder;
 
   /// Leading builder for directory
-  final FilexActionBuilder directoryLeadingBuilder;
+  final FilexActionBuilder? directoryLeadingBuilder;
 
   /// Extra slidable actions
   final List<FilexSlidableAction> extraActions;

--- a/lib/src/models/actions.dart
+++ b/lib/src/models/actions.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'filesystem.dart';
 
 /// Actions on slidable
@@ -9,20 +8,21 @@ enum PredefinedAction {
 }
 
 /// Action builder for leading and trailing widgets
-typedef Widget FilexActionBuilder(BuildContext context, DirectoryItem item);
+typedef FilexActionBuilder = Widget Function(
+    BuildContext context, DirectoryItem item);
 
 /// Action builder for slidable actions
-typedef void FilexSlidableActionBuilder(
+typedef FilexSlidableActionBuilder = void Function(
     BuildContext context, DirectoryItem item);
 
 /// Action for slidable
 class FilexSlidableAction {
   /// Default constructor
   FilexSlidableAction(
-      {@required this.color,
-      @required this.iconData,
-      @required this.name,
-      @required this.onTap});
+      {required this.color,
+      required this.iconData,
+      required this.name,
+      required this.onTap});
 
   final Color color;
   final IconData iconData;

--- a/lib/src/models/filesystem.dart
+++ b/lib/src/models/filesystem.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:path/path.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:filesize/filesize.dart' as fs;
 import '../file_icons.dart';
 
@@ -9,9 +8,9 @@ import '../file_icons.dart';
 class ListedDirectory {
   /// Default constructor
   ListedDirectory(
-      {@required this.directory,
-      @required this.listedDirectories,
-      @required this.listedFiles}) {
+      {required this.directory,
+      required this.listedDirectories,
+      required this.listedFiles}) {
     _getItems();
   }
 
@@ -24,7 +23,7 @@ class ListedDirectory {
   /// The files in the directory
   final List<File> listedFiles;
 
-  List<DirectoryItem> _items;
+  late List<DirectoryItem> _items;
 
   /// All the directory items
   List<DirectoryItem> get items => _items;
@@ -45,7 +44,7 @@ class ListedDirectory {
 /// A subdirectory item: file or directory
 class DirectoryItem {
   /// Default constructor
-  DirectoryItem({@required this.item}) {
+  DirectoryItem({required this.item}) {
     _filesize = _getFilesize(item);
     _filename = basename(item.path);
     _icon = _setIcon(item, _filename);
@@ -54,8 +53,8 @@ class DirectoryItem {
   /// The subdirectory or file
   final FileSystemEntity item;
 
-  String _filename;
-  Icon _icon;
+  late String _filename;
+  late Icon _icon;
   String _filesize = "";
 
   /// The icon too display

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,20 +5,19 @@ homepage: https://github.com/synw/filex
 version: 0.3.0
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.2 <3.0.0"
 
 dependencies:
+  extra_pedantic: ^1.5.0
+  filesize: ^2.0.1
   flutter:
     sdk: flutter
-  extra_pedantic: ^1.2.0
-  filesize: ^1.0.4
-  flutter_slidable: ^0.5.7
-  open_file: ^3.0.3
-  path: ^1.7.0
-  path_provider: ^1.6.24
-  pedantic: ^1.9.2
-  permission: ^0.1.7
-  rxdart: ^0.25.0
+  flutter_slidable: ^0.6.0
+  open_file: ^3.2.1
+  path: ^1.8.0
+  path_provider: ^2.0.2
+  pedantic: ^1.11.0
+  rxdart: ^0.27.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Migrated to null-safety.
Changed the example and removed the permission package.
`showOnlyDirectories` and `showHiddenFiles` resort to `false` by default.